### PR TITLE
Featurte/post inner word

### DIFF
--- a/laravel/app/Http/Controllers/InnerWordController.php
+++ b/laravel/app/Http/Controllers/InnerWordController.php
@@ -2,6 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\InnerWordRequest;
+use App\Models\InnerWord;
+use App\UseCase\InnerWord\ShowInnerWordListUseCase;
+use App\UseCase\InnerWord\StoreInnerWordUseCase;
 use Illuminate\Http\Request;
 
 class InnerWordController extends Controller
@@ -11,9 +15,13 @@ class InnerWordController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request, ShowInnerWordListUseCase $useCase)
     {
-        //
+      $thema_id = $request->thema_id;
+
+      return $useCase
+        ? response()->json($useCase($thema_id), 201)
+        : response()->json([], 500);
     }
 
     /**
@@ -32,9 +40,11 @@ class InnerWordController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(InnerWordRequest $request, StoreInnerWordUseCase $useCase)
     {
-        //
+      return $useCase
+      ? response()->json($useCase($request), 201)
+      : response()->json([], 500);
     }
 
     /**

--- a/laravel/app/Http/Requests/InnerWordRequest.php
+++ b/laravel/app/Http/Requests/InnerWordRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InnerWordRequest extends FormRequest
+{
+  /**
+   * Determine if the user is authorized to make this request.
+   *
+   * @return bool
+   */
+  public function authorize()
+  {
+    return true;
+  }
+
+  /**
+   * Get the validation rules that apply to the request.
+   *
+   * @return array
+   */
+  public function rules()
+  {
+    return [
+
+  ];
+  }
+}

--- a/laravel/app/Models/InnerWord.php
+++ b/laravel/app/Models/InnerWord.php
@@ -7,10 +7,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class InnerWord extends Model
 {
-    use HasFactory;
+  use HasFactory;
 
-    public function thema()
-    {
-        return $this->belongsTo(InnerWord::class);
-    }
+  protected $fillable = [
+    'thema_id',
+    'inner_word',
+  ];
+
+  public function thema()
+  {
+    return $this->belongsTo(InnerWord::class);
+  }
 }

--- a/laravel/app/UseCase/InnerWord/ShowInnerWordListUseCase.php
+++ b/laravel/app/UseCase/InnerWord/ShowInnerWordListUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\UseCase\InnerWord;
+
+use App\Models\InnerWord;
+
+final class ShowInnerWordListUseCase
+{
+   /**
+   *
+   * Get user's inner_words
+   *
+   * @return array
+   */
+  public function __invoke($thema_id): array
+  {
+    /**
+    *
+    */
+    $inner_word = InnerWord::query()
+      ->where('thema_id', '=', $thema_id)
+      ->orderBy('created_at', 'desc')
+      ->get();
+
+    return [
+      'inner_word' => $inner_word,
+    ];
+  }
+}

--- a/laravel/app/UseCase/InnerWord/StoreInnerWordUseCase.php
+++ b/laravel/app/UseCase/InnerWord/StoreInnerWordUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\UseCase\InnerWord;
+
+use App\Models\InnerWord;
+
+final class StoreInnerWordUseCase
+{
+   /**
+   *
+   * Sotre user's thema
+   * ・とりあえずstore処理だけ
+   *
+   * @return array
+   */
+  public function __invoke($request): array
+  {
+    /**
+    *
+    */
+    $inner_word = new InnerWord();
+    $inner_word->fill($request->all())->save();
+
+    return [
+      "inner_word" => $inner_word
+    ];
+  }
+}

--- a/laravel/database/migrations/2022_06_22_075931_create_inner_words_table.php
+++ b/laravel/database/migrations/2022_06_22_075931_create_inner_words_table.php
@@ -16,11 +16,11 @@ class CreateInnerWordsTable extends Migration
         Schema::create('inner_words', function (Blueprint $table) {
             $table->increments('id');
             $table->foreignId('thema_id')->comment('テーマID');
-            $table->string('Inner_word', 150)->comment('内なる言葉');
-            $table->string('so_word', 150)->comment('それで？の問い');
-            $table->string('really_word', 150)->comment('本当に？の問い');
-            $table->string('why_word', 150)->comment('なぜ？の問い');
-            $table->text('outside_word')->comment('外側への言葉');
+            $table->string('inner_word', 150)->comment('内なる言葉');
+            $table->string('so_word', 150)->nullable()->comment('それで？の問い');
+            $table->string('really_word', 150)->nullable()->comment('本当に？の問い');
+            $table->string('why_word', 150)->nullable()->comment('なぜ？の問い');
+            $table->text('outside_word')->nullable()->comment('外側への言葉');
             $table->timestamps();
         });
     }

--- a/laravel/public/js/app.js
+++ b/laravel/public/js/app.js
@@ -41093,6 +41093,34 @@ exports["default"] = _default;
 
 /***/ }),
 
+/***/ "./node_modules/@mui/icons-material/Create.js":
+/*!****************************************************!*\
+  !*** ./node_modules/@mui/icons-material/Create.js ***!
+  \****************************************************/
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+"use strict";
+
+
+var _interopRequireDefault = __webpack_require__(/*! @babel/runtime/helpers/interopRequireDefault */ "./node_modules/@babel/runtime/helpers/interopRequireDefault.js");
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _createSvgIcon = _interopRequireDefault(__webpack_require__(/*! ./utils/createSvgIcon */ "./node_modules/@mui/icons-material/utils/createSvgIcon.js"));
+
+var _jsxRuntime = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+
+var _default = (0, _createSvgIcon.default)( /*#__PURE__*/(0, _jsxRuntime.jsx)("path", {
+  d: "M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+}), 'Create');
+
+exports["default"] = _default;
+
+/***/ }),
+
 /***/ "./node_modules/@mui/icons-material/Email.js":
 /*!***************************************************!*\
   !*** ./node_modules/@mui/icons-material/Email.js ***!
@@ -48614,17 +48642,11 @@ var react_dom_1 = __importDefault(__webpack_require__(/*! react-dom */ "./node_m
 /* contexts */
 
 
-var ThemaContext_1 = __webpack_require__(/*! ./contexts/ThemaContext */ "./resources/ts/contexts/ThemaContext.ts");
-
 var UserContext_1 = __webpack_require__(/*! ./contexts/UserContext */ "./resources/ts/contexts/UserContext.ts");
-/* routes */
 
+var LoggedRouter_1 = __webpack_require__(/*! ./routes/LoggedRouter */ "./resources/ts/routes/LoggedRouter.tsx");
 
-var NotLoginRouter_1 = __webpack_require__(/*! ./routes/NotLoginRouter */ "./resources/ts/routes/NotLoginRouter.tsx");
-/* screens */
-
-
-var TopScreen_1 = __webpack_require__(/*! ./screens/TopScreen */ "./resources/ts/screens/TopScreen.tsx");
+var WelcomeScreen_1 = __webpack_require__(/*! ./screens/WelcomeScreen */ "./resources/ts/screens/WelcomeScreen.tsx");
 /* material-ui */
 
 
@@ -48650,11 +48672,6 @@ function App() {
       user = _ref2[0],
       setUser = _ref2[1];
 
-  var _ref3 = (0, react_1.useState)([]),
-      _ref4 = _slicedToArray(_ref3, 2),
-      themas = _ref4[0],
-      setThemas = _ref4[1];
-
   (0, react_1.useEffect)(function () {
     if (localStorage.getItem("loginUser")) {
       var userStrageText = localStorage.getItem('loginUser');
@@ -48669,12 +48686,7 @@ function App() {
       user: user,
       setUser: setUser
     }
-  }, react_1["default"].createElement(ThemaContext_1.ThemaContexts.Provider, {
-    value: {
-      themas: themas,
-      setThemas: setThemas
-    }
-  }, !user ? react_1["default"].createElement(NotLoginRouter_1.NotLoginRouter, null) : react_1["default"].createElement(TopScreen_1.TopScreen, null))));
+  }, !user ? react_1["default"].createElement(WelcomeScreen_1.WelcomeScreen, null) : react_1["default"].createElement(LoggedRouter_1.LoggedRouter, null)));
 }
 
 exports["default"] = App;
@@ -48682,6 +48694,671 @@ exports["default"] = App;
 if (document.getElementById('app')) {
   react_dom_1["default"].render(react_1["default"].createElement(App, null), document.getElementById('app'));
 }
+
+/***/ }),
+
+/***/ "./resources/ts/components/InnerWordForm.tsx":
+/*!***************************************************!*\
+  !*** ./resources/ts/components/InnerWordForm.tsx ***!
+  \***************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var __createBinding = this && this.__createBinding || (Object.create ? function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+    desc = {
+      enumerable: true,
+      get: function get() {
+        return m[k];
+      }
+    };
+  }
+
+  Object.defineProperty(o, k2, desc);
+} : function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+var __setModuleDefault = this && this.__setModuleDefault || (Object.create ? function (o, v) {
+  Object.defineProperty(o, "default", {
+    enumerable: true,
+    value: v
+  });
+} : function (o, v) {
+  o["default"] = v;
+});
+
+var __importStar = this && this.__importStar || function (mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) {
+    if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  }
+
+  __setModuleDefault(result, mod);
+
+  return result;
+};
+
+var __awaiter = this && this.__awaiter || function (thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function (resolve) {
+      resolve(value);
+    });
+  }
+
+  return new (P || (P = Promise))(function (resolve, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+
+    function step(result) {
+      result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+
+var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    "default": mod
+  };
+};
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.InnerWordForm = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* contexts */
+
+
+var UserContext_1 = __webpack_require__(/*! ../contexts/UserContext */ "./resources/ts/contexts/UserContext.ts");
+
+var axios_1 = __importDefault(__webpack_require__(/*! axios */ "./node_modules/axios/index.js"));
+
+var InnerWordContext_1 = __webpack_require__(/*! ../contexts/InnerWordContext */ "./resources/ts/contexts/InnerWordContext.ts");
+/* material-ui */
+
+
+var styles_1 = __webpack_require__(/*! @material-ui/core/styles */ "./node_modules/@material-ui/core/esm/styles/index.js");
+
+var core_1 = __webpack_require__(/*! @material-ui/core */ "./node_modules/@material-ui/core/esm/index.js"); // ---[ style ]-----------------------------------------------------------------
+
+
+var useStyles = (0, styles_1.makeStyles)(function (theme) {
+  return (0, styles_1.createStyles)({
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+      padding: 16,
+      borderBottom: '1px solid black'
+    },
+    container_innner_top: {},
+    container_innner_bottom: {
+      marginTop: 8,
+      display: 'flex',
+      flexDirection: 'row-reverse'
+    },
+    input_thema: {
+      width: '100%'
+    },
+    thema_submit: {
+      borderRadius: 50
+    }
+  });
+}); // ---[ types ]-----------------------------------------------------------------
+// ---[ process ]---------------------------------------------------------------
+
+var InnerWordForm = function InnerWordForm() {
+  var classes = useStyles(); // Set state
+
+  var _ref = (0, react_1.useContext)(InnerWordContext_1.InnerWordContexts),
+      innerWords = _ref.innerWords,
+      setInnerWords = _ref.setInnerWords;
+
+  var _ref2 = (0, react_1.useContext)(UserContext_1.UserContext),
+      user = _ref2.user,
+      setUser = _ref2.setUser;
+
+  var _ref3 = (0, react_1.useState)(''),
+      _ref4 = _slicedToArray(_ref3, 2),
+      innerWord = _ref4[0],
+      setInnerWord = _ref4[1];
+
+  var themaId = (0, react_router_dom_1.useParams)().thema_id;
+
+  var innerWordPost = function innerWordPost() {
+    return __awaiter(void 0, void 0, void 0, /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              if (!(innerWord === '')) {
+                _context.next = 2;
+                break;
+              }
+
+              return _context.abrupt("return", null);
+
+            case 2:
+              _context.prev = 2;
+              _context.next = 5;
+              return axios_1["default"].post("//localhost/api/inner_words/store", {
+                thema_id: themaId,
+                inner_word: innerWord
+              }).then(function (res) {
+                var resInnerWord = {
+                  id: res.data.inner_word.id,
+                  thema_id: Number(res.data.inner_word.user_id),
+                  inner_word: res.data.inner_word.inner_word,
+                  so_word: res.data.inner_word.so_word,
+                  really_word: res.data.inner_word.really_word,
+                  why_word: res.data.inner_word.why_word,
+                  outside_word: res.data.inner_word.outside_word,
+                  updated_at: res.data.inner_word.updated_at,
+                  created_at: res.data.inner_word.created_at
+                };
+                setInnerWords([resInnerWord].concat(_toConsumableArray(innerWords))); // 初期化
+
+                setInnerWord('');
+              })["catch"](function (error) {
+                console.log(error);
+              });
+
+            case 5:
+              _context.next = 10;
+              break;
+
+            case 7:
+              _context.prev = 7;
+              _context.t0 = _context["catch"](2);
+              console.error(_context.t0);
+
+            case 10:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee, null, [[2, 7]]);
+    }));
+  }; // input type onChange logic
+
+
+  var inputChangeForm = function inputChangeForm(input) {
+    var value = input.target.value; // setState
+
+    setInnerWord(value);
+  };
+
+  return react_1["default"].createElement(react_1["default"].Fragment, null, react_1["default"].createElement("form", {
+    className: classes.container,
+    method: 'post'
+  }, react_1["default"].createElement(core_1.TextField, {
+    className: classes.input_thema,
+    label: "\u5185\u306A\u308B\u8A00\u8449\u3092\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044",
+    variant: 'outlined',
+    onChange: inputChangeForm,
+    value: innerWord,
+    name: 'innerWord'
+  }), react_1["default"].createElement(core_1.Box, {
+    className: classes.container_innner_bottom
+  }, react_1["default"].createElement(core_1.Button, {
+    className: classes.thema_submit,
+    variant: 'contained',
+    color: 'primary',
+    onClick: innerWordPost
+  }, "\u4F5C\u6210\u3059\u308B"))));
+};
+
+exports.InnerWordForm = InnerWordForm;
+
+/***/ }),
+
+/***/ "./resources/ts/components/InnerWordHeader.tsx":
+/*!*****************************************************!*\
+  !*** ./resources/ts/components/InnerWordHeader.tsx ***!
+  \*****************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    "default": mod
+  };
+};
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.InnerWordHeader = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __importDefault(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* material-ui */
+
+
+var styles_1 = __webpack_require__(/*! @material-ui/core/styles */ "./node_modules/@material-ui/core/esm/styles/index.js");
+
+var core_1 = __webpack_require__(/*! @material-ui/core */ "./node_modules/@material-ui/core/esm/index.js");
+/* material-ui icon */
+
+
+var MoreHoriz_1 = __importDefault(__webpack_require__(/*! @mui/icons-material/MoreHoriz */ "./node_modules/@mui/icons-material/MoreHoriz.js")); // ---[ styles ]----------------------------------------------------------------
+
+
+var useStyles = (0, styles_1.makeStyles)(function (theme) {
+  return (0, styles_1.createStyles)({
+    container: {
+      display: 'flex',
+      flex: 1,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      padding: 16,
+      marginBottom: 16,
+      borderBottom: '1px solid black'
+    },
+    left_container: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'start'
+    },
+    center_container: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center'
+    },
+    right_container: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'end'
+    }
+  });
+}); // ---[ styles ]----------------------------------------------------------------
+
+var InnerWordHeader = function InnerWordHeader() {
+  // style
+  var classes = useStyles();
+  return react_1["default"].createElement(core_1.Container, {
+    className: classes.container
+  }, react_1["default"].createElement(core_1.Box, {
+    className: classes.left_container
+  }, react_1["default"].createElement(react_router_dom_1.Link, {
+    to: "/"
+  }, "\u623B\u308B")), react_1["default"].createElement(core_1.Box, {
+    className: classes.center_container
+  }, react_1["default"].createElement(core_1.Typography, {
+    variant: "h5"
+  }, "\u5185\u306A\u308B\u8A00\u8449")), react_1["default"].createElement(core_1.Box, {
+    className: classes.right_container
+  }, react_1["default"].createElement(MoreHoriz_1["default"], null)));
+};
+
+exports.InnerWordHeader = InnerWordHeader;
+
+/***/ }),
+
+/***/ "./resources/ts/components/InnerWordList.tsx":
+/*!***************************************************!*\
+  !*** ./resources/ts/components/InnerWordList.tsx ***!
+  \***************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+var __createBinding = this && this.__createBinding || (Object.create ? function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+    desc = {
+      enumerable: true,
+      get: function get() {
+        return m[k];
+      }
+    };
+  }
+
+  Object.defineProperty(o, k2, desc);
+} : function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+var __setModuleDefault = this && this.__setModuleDefault || (Object.create ? function (o, v) {
+  Object.defineProperty(o, "default", {
+    enumerable: true,
+    value: v
+  });
+} : function (o, v) {
+  o["default"] = v;
+});
+
+var __importStar = this && this.__importStar || function (mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) {
+    if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  }
+
+  __setModuleDefault(result, mod);
+
+  return result;
+};
+
+var __awaiter = this && this.__awaiter || function (thisArg, _arguments, P, generator) {
+  function adopt(value) {
+    return value instanceof P ? value : new P(function (resolve) {
+      resolve(value);
+    });
+  }
+
+  return new (P || (P = Promise))(function (resolve, reject) {
+    function fulfilled(value) {
+      try {
+        step(generator.next(value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+
+    function rejected(value) {
+      try {
+        step(generator["throw"](value));
+      } catch (e) {
+        reject(e);
+      }
+    }
+
+    function step(result) {
+      result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+    }
+
+    step((generator = generator.apply(thisArg, _arguments || [])).next());
+  });
+};
+
+var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    "default": mod
+  };
+};
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.InnerWordList = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+
+var axios_1 = __importDefault(__webpack_require__(/*! axios */ "./node_modules/axios/index.js"));
+/* contexts */
+
+
+var UserContext_1 = __webpack_require__(/*! ../contexts/UserContext */ "./resources/ts/contexts/UserContext.ts");
+
+var InnerWordContext_1 = __webpack_require__(/*! ../contexts/InnerWordContext */ "./resources/ts/contexts/InnerWordContext.ts");
+/* material-ui */
+
+
+var styles_1 = __webpack_require__(/*! @material-ui/core/styles */ "./node_modules/@material-ui/core/esm/styles/index.js");
+
+var core_1 = __webpack_require__(/*! @material-ui/core */ "./node_modules/@material-ui/core/esm/index.js");
+/* material-ui icon */
+
+
+var StarBorder_1 = __importDefault(__webpack_require__(/*! @mui/icons-material/StarBorder */ "./node_modules/@mui/icons-material/StarBorder.js"));
+
+var MoreHoriz_1 = __importDefault(__webpack_require__(/*! @mui/icons-material/MoreHoriz */ "./node_modules/@mui/icons-material/MoreHoriz.js"));
+
+var Create_1 = __importDefault(__webpack_require__(/*! @mui/icons-material/Create */ "./node_modules/@mui/icons-material/Create.js")); // ---[ styles ]----------------------------------------------------------------
+
+
+var useStyles = (0, styles_1.makeStyles)(function (theme) {
+  return (0, styles_1.createStyles)({
+    // container
+    container: {
+      display: 'flex',
+      flex: 1,
+      flexDirection: 'column',
+      padding: 16
+    },
+    // container_parts
+    container_innner_top: {
+      display: 'flex',
+      flex: 1,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: 16
+    },
+    container_innner_middle: {
+      padding: 16
+    },
+    container_innner_bottom: {
+      display: 'flex',
+      flexDirection: 'row-reverse',
+      marginTop: 16
+    },
+    // container_parts_items
+    input_search: {
+      width: '200px'
+    },
+    list_item: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      marginBottom: 8
+    },
+    list_item_right: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '64px',
+      backgroundColor: '#fff',
+      border: '1px solid black',
+      borderRight: 0,
+      borderTopLeftRadius: 5,
+      borderBottomLeftRadius: 5
+    },
+    list_item_center: {
+      display: 'flex',
+      flex: 10,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: 8,
+      height: '64px',
+      backgroundColor: '#fff',
+      border: '1px solid black'
+    },
+    list_item_thema_input: {
+      width: '100%'
+    },
+    list_item_inner_prev: {
+      display: 'flex',
+      flex: 1,
+      backgroundColor: '#fff',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '64px',
+      border: '1px solid black',
+      borderLeft: 0,
+      borderTopRightRadius: 5,
+      borderBottomRightRadius: 5,
+      "&:hover": {
+        background: "steelblue",
+        cursor: 'pointer'
+      }
+    }
+  });
+}); // ---[ process ]---------------------------------------------------------------
+
+var InnerWordList = function InnerWordList() {
+  // style
+  var classes = useStyles();
+  var navigate = (0, react_router_dom_1.useNavigate)(); // stateを宣言
+
+  var _ref = (0, react_1.useContext)(UserContext_1.UserContext),
+      user = _ref.user,
+      setUser = _ref.setUser;
+
+  var _ref2 = (0, react_1.useContext)(InnerWordContext_1.InnerWordContexts),
+      innerWords = _ref2.innerWords,
+      setInnerWords = _ref2.setInnerWords;
+
+  var themaId = (0, react_router_dom_1.useParams)().thema_id; // 画面マウント時
+
+  (0, react_1.useEffect)(function () {
+    fetchInnerWords();
+  }, []); // 内なる言葉を取得
+
+  var fetchInnerWords = function fetchInnerWords() {
+    return __awaiter(void 0, void 0, void 0, /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      var innerWordList;
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.prev = 0;
+              _context.next = 3;
+              return axios_1["default"].get("//localhost/api/inner_words?thema_id=".concat(themaId));
+
+            case 3:
+              innerWordList = _context.sent;
+              setInnerWords(innerWordList.data.inner_word);
+              _context.next = 10;
+              break;
+
+            case 7:
+              _context.prev = 7;
+              _context.t0 = _context["catch"](0);
+              console.error(_context.t0);
+
+            case 10:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee, null, [[0, 7]]);
+    }));
+  }; // 内なる言葉の変更処理
+
+
+  var onChangeInnerWord = function onChangeInnerWord(input, index) {
+    setInnerWords(innerWords.map(function (obj, objIndex) {
+      return index === objIndex ? Object.assign(Object.assign({}, obj), {
+        inner_word: input.target.value
+      }) : obj;
+    })); // feature update api logic
+  }; // 内なる言葉の詳細へ
+
+
+  var prevInnerWordDetail = function prevInnerWordDetail(input, innerWord) {
+    navigate("/inner_word/".concat(innerWord));
+  }; // returns element
+
+
+  return react_1["default"].createElement(core_1.Box, {
+    className: classes.container
+  }, react_1["default"].createElement(core_1.Box, {
+    className: classes.container_innner_top
+  }, react_1["default"].createElement(core_1.Typography, null, "\u5185\u306A\u308B\u8A00\u8449"), react_1["default"].createElement(core_1.TextField, {
+    id: 'filled-search',
+    className: classes.input_search,
+    label: "\u691C\u7D22\u3059\u308B",
+    variant: 'filled',
+    InputProps: {
+      disableUnderline: true
+    }
+  })), react_1["default"].createElement(core_1.Box, {
+    className: classes.container_innner_middle
+  }, "feature: A component of sorts will go in here."), react_1["default"].createElement(core_1.Box, null, react_1["default"].createElement(core_1.List, null, innerWords.map(function (innerWord, index) {
+    return react_1["default"].createElement(core_1.ListItem, {
+      key: index.toString(),
+      className: classes.list_item
+    }, react_1["default"].createElement(core_1.Box, {
+      className: classes.list_item_right
+    }, react_1["default"].createElement(StarBorder_1["default"], null)), react_1["default"].createElement(core_1.Box, {
+      className: classes.list_item_center
+    }, react_1["default"].createElement(core_1.TextField, {
+      className: classes.list_item_thema_input,
+      id: 'outlined',
+      InputProps: {
+        disableUnderline: true
+      },
+      value: innerWord.inner_word,
+      onChange: function onChange(e) {
+        return onChangeInnerWord(e, index);
+      }
+    }), react_1["default"].createElement(MoreHoriz_1["default"], null)), react_1["default"].createElement(core_1.Box, {
+      className: classes.list_item_inner_prev,
+      onClick: function onClick(e) {
+        return prevInnerWordDetail(e, innerWord.id);
+      }
+    }, react_1["default"].createElement(Create_1["default"], null)));
+  }))));
+};
+
+exports.InnerWordList = InnerWordList;
 
 /***/ }),
 
@@ -48783,13 +49460,13 @@ exports.ThemaList = void 0; // ---[ import ]------------------------------------
 
 var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
 
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+
 var axios_1 = __importDefault(__webpack_require__(/*! axios */ "./node_modules/axios/index.js"));
 /* contexts */
 
 
 var UserContext_1 = __webpack_require__(/*! ../contexts/UserContext */ "./resources/ts/contexts/UserContext.ts");
-/* contexts */
-
 
 var ThemaContext_1 = __webpack_require__(/*! ../contexts/ThemaContext */ "./resources/ts/contexts/ThemaContext.ts");
 /* material-ui */
@@ -48878,14 +49555,19 @@ var useStyles = (0, styles_1.makeStyles)(function (theme) {
       border: '1px solid black',
       borderLeft: 0,
       borderTopRightRadius: 5,
-      borderBottomRightRadius: 5
+      borderBottomRightRadius: 5,
+      "&:hover": {
+        background: "steelblue",
+        cursor: 'pointer'
+      }
     }
   });
 }); // ---[ process ]---------------------------------------------------------------
 
 var ThemaList = function ThemaList() {
   // style
-  var classes = useStyles(); // state
+  var classes = useStyles();
+  var navigate = (0, react_router_dom_1.useNavigate)(); // state
 
   var _ref = (0, react_1.useContext)(UserContext_1.UserContext),
       user = _ref.user,
@@ -48942,6 +49624,10 @@ var ThemaList = function ThemaList() {
     })); // feature update api logic
   };
 
+  var prevInnerWord = function prevInnerWord(input, thema_id) {
+    navigate("/inner_word/".concat(thema_id));
+  };
+
   return react_1["default"].createElement(react_1["default"].Fragment, null, react_1["default"].createElement(core_1.Box, {
     className: classes.container
   }, react_1["default"].createElement(core_1.Box, {
@@ -48975,7 +49661,10 @@ var ThemaList = function ThemaList() {
         return onChangeThema(e, index);
       }
     }), react_1["default"].createElement(MoreHoriz_1["default"], null)), react_1["default"].createElement(core_1.Box, {
-      className: classes.list_item_inner_prev
+      className: classes.list_item_inner_prev,
+      onClick: function onClick(e) {
+        return prevInnerWord(e, thema.id);
+      }
     }, react_1["default"].createElement(NavigateNext_1["default"], null)));
   })))));
 };
@@ -48984,9 +49673,9 @@ exports.ThemaList = ThemaList;
 
 /***/ }),
 
-/***/ "./resources/ts/components/form/Thema.tsx":
+/***/ "./resources/ts/components/form/thema.tsx":
 /*!************************************************!*\
-  !*** ./resources/ts/components/form/Thema.tsx ***!
+  !*** ./resources/ts/components/form/thema.tsx ***!
   \************************************************/
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
@@ -49248,6 +49937,30 @@ exports.CreateThemaForm = CreateThemaForm;
 
 /***/ }),
 
+/***/ "./resources/ts/contexts/InnerWordContext.ts":
+/*!***************************************************!*\
+  !*** ./resources/ts/contexts/InnerWordContext.ts ***!
+  \***************************************************/
+/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.InnerWordContexts = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js"); // ---[ process ]---------------------------------------------------------------
+
+
+exports.InnerWordContexts = (0, react_1.createContext)({
+  innerWords: [],
+  setInnerWords: function setInnerWords() {}
+});
+
+/***/ }),
+
 /***/ "./resources/ts/contexts/ThemaContext.ts":
 /*!***********************************************!*\
   !*** ./resources/ts/contexts/ThemaContext.ts ***!
@@ -49296,10 +50009,10 @@ exports.UserContext = (0, react_1.createContext)({
 
 /***/ }),
 
-/***/ "./resources/ts/routes/NotLoginRouter.tsx":
-/*!************************************************!*\
-  !*** ./resources/ts/routes/NotLoginRouter.tsx ***!
-  \************************************************/
+/***/ "./resources/ts/routes/LoggedRouter.tsx":
+/*!**********************************************!*\
+  !*** ./resources/ts/routes/LoggedRouter.tsx ***!
+  \**********************************************/
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -49314,13 +50027,17 @@ var __importDefault = this && this.__importDefault || function (mod) {
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.NotLoginRouter = void 0; // ---[ import ]----------------------------------------------------------------
+exports.LoggedRouter = void 0; // ---[ import ]----------------------------------------------------------------
 
 var react_1 = __importDefault(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
 
 var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* screens */
 
-var WelcomeScreen_1 = __webpack_require__(/*! ../screens/WelcomeScreen */ "./resources/ts/screens/WelcomeScreen.tsx");
+
+var TopScreen_1 = __webpack_require__(/*! ../screens/TopScreen */ "./resources/ts/screens/TopScreen.tsx");
+
+var InnerWordScreen_1 = __webpack_require__(/*! ../screens/InnerWordScreen */ "./resources/ts/screens/InnerWordScreen.tsx");
 
 var RegisterScreen_1 = __webpack_require__(/*! ../screens/RegisterScreen */ "./resources/ts/screens/RegisterScreen.tsx");
 
@@ -49329,10 +50046,13 @@ var LoginScreen_1 = __webpack_require__(/*! ../screens/LoginScreen */ "./resourc
 var PageNotFound_1 = __webpack_require__(/*! ../screens/PageNotFound */ "./resources/ts/screens/PageNotFound.tsx"); // ---[ styles ]----------------------------------------------------------------
 
 
-var NotLoginRouter = function NotLoginRouter() {
+var LoggedRouter = function LoggedRouter() {
   return react_1["default"].createElement(react_1["default"].Fragment, null, react_1["default"].createElement(react_router_dom_1.BrowserRouter, null, react_1["default"].createElement(react_router_dom_1.Routes, null, react_1["default"].createElement(react_router_dom_1.Route, {
     path: "/",
-    element: react_1["default"].createElement(WelcomeScreen_1.WelcomeScreen, null)
+    element: react_1["default"].createElement(TopScreen_1.TopScreen, null)
+  }), react_1["default"].createElement(react_router_dom_1.Route, {
+    path: "/inner_word/:thema_id",
+    element: react_1["default"].createElement(InnerWordScreen_1.InnerWordScreen, null)
   }), react_1["default"].createElement(react_router_dom_1.Route, {
     path: "/login",
     element: react_1["default"].createElement(LoginScreen_1.LoginScreen, null)
@@ -49345,7 +50065,125 @@ var NotLoginRouter = function NotLoginRouter() {
   }))));
 };
 
-exports.NotLoginRouter = NotLoginRouter;
+exports.LoggedRouter = LoggedRouter;
+
+/***/ }),
+
+/***/ "./resources/ts/screens/InnerWordScreen.tsx":
+/*!**************************************************!*\
+  !*** ./resources/ts/screens/InnerWordScreen.tsx ***!
+  \**************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var __createBinding = this && this.__createBinding || (Object.create ? function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+    desc = {
+      enumerable: true,
+      get: function get() {
+        return m[k];
+      }
+    };
+  }
+
+  Object.defineProperty(o, k2, desc);
+} : function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+var __setModuleDefault = this && this.__setModuleDefault || (Object.create ? function (o, v) {
+  Object.defineProperty(o, "default", {
+    enumerable: true,
+    value: v
+  });
+} : function (o, v) {
+  o["default"] = v;
+});
+
+var __importStar = this && this.__importStar || function (mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) {
+    if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  }
+
+  __setModuleDefault(result, mod);
+
+  return result;
+};
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.InnerWordScreen = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+/* contexts */
+
+
+var InnerWordContext_1 = __webpack_require__(/*! ../contexts/InnerWordContext */ "./resources/ts/contexts/InnerWordContext.ts");
+/* components */
+
+
+var InnerWordForm_1 = __webpack_require__(/*! ../components/InnerWordForm */ "./resources/ts/components/InnerWordForm.tsx");
+
+var InnerWordList_1 = __webpack_require__(/*! ../components/InnerWordList */ "./resources/ts/components/InnerWordList.tsx");
+
+var InnerWordHeader_1 = __webpack_require__(/*! ../components/InnerWordHeader */ "./resources/ts/components/InnerWordHeader.tsx");
+/* material-ui */
+
+
+var styles_1 = __webpack_require__(/*! @material-ui/core/styles */ "./node_modules/@material-ui/core/esm/styles/index.js");
+
+var core_1 = __webpack_require__(/*! @material-ui/core */ "./node_modules/@material-ui/core/esm/index.js"); // ---[ styles ]----------------------------------------------------------------
+
+
+var useStyles = (0, styles_1.makeStyles)(function (theme) {
+  return (0, styles_1.createStyles)({
+    container: {
+      width: "80%"
+    }
+  });
+}); // ---[ styles ]----------------------------------------------------------------
+
+var InnerWordScreen = function InnerWordScreen() {
+  // style
+  var classes = useStyles();
+
+  var _ref = (0, react_1.useState)([]),
+      _ref2 = _slicedToArray(_ref, 2),
+      innerWords = _ref2[0],
+      setInnerWords = _ref2[1];
+
+  return react_1["default"].createElement(core_1.Container, {
+    className: classes.container
+  }, react_1["default"].createElement(InnerWordContext_1.InnerWordContexts.Provider, {
+    value: {
+      innerWords: innerWords,
+      setInnerWords: setInnerWords
+    }
+  }, react_1["default"].createElement(InnerWordHeader_1.InnerWordHeader, null), react_1["default"].createElement(InnerWordForm_1.InnerWordForm, null), react_1["default"].createElement(InnerWordList_1.InnerWordList, null)));
+};
+
+exports.InnerWordScreen = InnerWordScreen;
 
 /***/ }),
 
@@ -50060,10 +50898,56 @@ exports.RegisterScreen = RegisterScreen;
 "use strict";
 
 
-var __importDefault = this && this.__importDefault || function (mod) {
-  return mod && mod.__esModule ? mod : {
-    "default": mod
-  };
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var __createBinding = this && this.__createBinding || (Object.create ? function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  var desc = Object.getOwnPropertyDescriptor(m, k);
+
+  if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+    desc = {
+      enumerable: true,
+      get: function get() {
+        return m[k];
+      }
+    };
+  }
+
+  Object.defineProperty(o, k2, desc);
+} : function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k;
+  o[k2] = m[k];
+});
+
+var __setModuleDefault = this && this.__setModuleDefault || (Object.create ? function (o, v) {
+  Object.defineProperty(o, "default", {
+    enumerable: true,
+    value: v
+  });
+} : function (o, v) {
+  o["default"] = v;
+});
+
+var __importStar = this && this.__importStar || function (mod) {
+  if (mod && mod.__esModule) return mod;
+  var result = {};
+  if (mod != null) for (var k in mod) {
+    if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+  }
+
+  __setModuleDefault(result, mod);
+
+  return result;
 };
 
 Object.defineProperty(exports, "__esModule", ({
@@ -50071,11 +50955,15 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports.TopScreen = void 0; // ---[ import ]----------------------------------------------------------------
 
-var react_1 = __importDefault(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+/* contexts */
+
+
+var ThemaContext_1 = __webpack_require__(/*! ../contexts/ThemaContext */ "./resources/ts/contexts/ThemaContext.ts");
 /* components */
 
 
-var Thema_1 = __webpack_require__(/*! ../components/form/Thema */ "./resources/ts/components/form/Thema.tsx");
+var thema_1 = __webpack_require__(/*! ../components/form/thema */ "./resources/ts/components/form/thema.tsx");
 
 var ThemaList_1 = __webpack_require__(/*! ../components/ThemaList */ "./resources/ts/components/ThemaList.tsx");
 /* material-ui */
@@ -50097,9 +50985,20 @@ var useStyles = (0, styles_1.makeStyles)(function (theme) {
 var TopScreen = function TopScreen() {
   // style
   var classes = useStyles();
+
+  var _ref = (0, react_1.useState)([]),
+      _ref2 = _slicedToArray(_ref, 2),
+      themas = _ref2[0],
+      setThemas = _ref2[1];
+
   return react_1["default"].createElement(core_1.Container, {
     className: classes.container
-  }, react_1["default"].createElement(Thema_1.CreateThemaForm, null), react_1["default"].createElement(ThemaList_1.ThemaList, null));
+  }, react_1["default"].createElement(ThemaContext_1.ThemaContexts.Provider, {
+    value: {
+      themas: themas,
+      setThemas: setThemas
+    }
+  }, react_1["default"].createElement(thema_1.CreateThemaForm, null), react_1["default"].createElement(ThemaList_1.ThemaList, null)));
 };
 
 exports.TopScreen = TopScreen;

--- a/laravel/public/js/app.js
+++ b/laravel/public/js/app.js
@@ -48643,10 +48643,12 @@ var react_dom_1 = __importDefault(__webpack_require__(/*! react-dom */ "./node_m
 
 
 var UserContext_1 = __webpack_require__(/*! ./contexts/UserContext */ "./resources/ts/contexts/UserContext.ts");
+/* routes */
+
+
+var NotLoginRouter_1 = __webpack_require__(/*! ./routes/NotLoginRouter */ "./resources/ts/routes/NotLoginRouter.tsx");
 
 var LoggedRouter_1 = __webpack_require__(/*! ./routes/LoggedRouter */ "./resources/ts/routes/LoggedRouter.tsx");
-
-var WelcomeScreen_1 = __webpack_require__(/*! ./screens/WelcomeScreen */ "./resources/ts/screens/WelcomeScreen.tsx");
 /* material-ui */
 
 
@@ -48686,7 +48688,7 @@ function App() {
       user: user,
       setUser: setUser
     }
-  }, !user ? react_1["default"].createElement(WelcomeScreen_1.WelcomeScreen, null) : react_1["default"].createElement(LoggedRouter_1.LoggedRouter, null)));
+  }, !user ? react_1["default"].createElement(NotLoginRouter_1.NotLoginRouter, null) : react_1["default"].createElement(LoggedRouter_1.LoggedRouter, null)));
 }
 
 exports["default"] = App;
@@ -50069,6 +50071,59 @@ exports.LoggedRouter = LoggedRouter;
 
 /***/ }),
 
+/***/ "./resources/ts/routes/NotLoginRouter.tsx":
+/*!************************************************!*\
+  !*** ./resources/ts/routes/NotLoginRouter.tsx ***!
+  \************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var __importDefault = this && this.__importDefault || function (mod) {
+  return mod && mod.__esModule ? mod : {
+    "default": mod
+  };
+};
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.NotLoginRouter = void 0; // ---[ import ]----------------------------------------------------------------
+
+var react_1 = __importDefault(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
+
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+
+var WelcomeScreen_1 = __webpack_require__(/*! ../screens/WelcomeScreen */ "./resources/ts/screens/WelcomeScreen.tsx");
+
+var RegisterScreen_1 = __webpack_require__(/*! ../screens/RegisterScreen */ "./resources/ts/screens/RegisterScreen.tsx");
+
+var LoginScreen_1 = __webpack_require__(/*! ../screens/LoginScreen */ "./resources/ts/screens/LoginScreen.tsx");
+
+var PageNotFound_1 = __webpack_require__(/*! ../screens/PageNotFound */ "./resources/ts/screens/PageNotFound.tsx"); // ---[ styles ]----------------------------------------------------------------
+
+
+var NotLoginRouter = function NotLoginRouter() {
+  return react_1["default"].createElement(react_1["default"].Fragment, null, react_1["default"].createElement(react_router_dom_1.BrowserRouter, null, react_1["default"].createElement(react_router_dom_1.Routes, null, react_1["default"].createElement(react_router_dom_1.Route, {
+    path: "/",
+    element: react_1["default"].createElement(WelcomeScreen_1.WelcomeScreen, null)
+  }), react_1["default"].createElement(react_router_dom_1.Route, {
+    path: "/login",
+    element: react_1["default"].createElement(LoginScreen_1.LoginScreen, null)
+  }), react_1["default"].createElement(react_router_dom_1.Route, {
+    path: "/register",
+    element: react_1["default"].createElement(RegisterScreen_1.RegisterScreen, null)
+  }), react_1["default"].createElement(react_router_dom_1.Route, {
+    path: "*",
+    element: react_1["default"].createElement(PageNotFound_1.PageNotFound, null)
+  }))));
+};
+
+exports.NotLoginRouter = NotLoginRouter;
+
+/***/ }),
+
 /***/ "./resources/ts/screens/InnerWordScreen.tsx":
 /*!**************************************************!*\
   !*** ./resources/ts/screens/InnerWordScreen.tsx ***!
@@ -50297,6 +50352,8 @@ exports.LoginScreen = void 0; // ---[ import ]----------------------------------
 
 var react_1 = __importStar(__webpack_require__(/*! react */ "./node_modules/react/index.js"));
 
+var react_router_dom_1 = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+
 var axios_1 = __importDefault(__webpack_require__(/*! axios */ "./node_modules/axios/index.js"));
 /* contexts */
 
@@ -50372,7 +50429,8 @@ var useStyles = (0, styles_1.makeStyles)(function (theme) {
 }); // ---[ process ]---------------------------------------------------------------
 
 var LoginScreen = function LoginScreen() {
-  var classes = useStyles(); // state
+  var classes = useStyles();
+  var navigate = (0, react_router_dom_1.useNavigate)(); // state
 
   var _ref = (0, react_1.useContext)(UserContext_1.UserContext),
       user = _ref.user,
@@ -50430,20 +50488,21 @@ var LoginScreen = function LoginScreen() {
               });
 
             case 3:
-              _context.next = 8;
+              navigate('/');
+              _context.next = 9;
               break;
 
-            case 5:
-              _context.prev = 5;
+            case 6:
+              _context.prev = 6;
               _context.t0 = _context["catch"](0);
               console.error(_context.t0);
 
-            case 8:
+            case 9:
             case "end":
               return _context.stop();
           }
         }
-      }, _callee, null, [[0, 5]]);
+      }, _callee, null, [[0, 6]]);
     }));
   }; // input state onChange logic
 

--- a/laravel/resources/ts/app.tsx
+++ b/laravel/resources/ts/app.tsx
@@ -3,18 +3,18 @@ import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 /* contexts */
-import { ThemaContexts } from './contexts/ThemaContext';
 import { UserContext } from './contexts/UserContext';
 
 /* type */
-import { Thema } from './type/Thema';
 import { User } from './type/User';
 
 /* routes */
 import { NotLoginRouter } from './routes/NotLoginRouter';
+import { LoggedRouter } from './routes/LoggedRouter';
 
 /* screens */
 import { TopScreen } from './screens/TopScreen';
+import { WelcomeScreen } from './screens/WelcomeScreen';
 
 /* material-ui */
 import { createStyles, makeStyles } from '@material-ui/core/styles';
@@ -35,7 +35,6 @@ export default function App() {
   const classes = useStyles();
 
   const [user, setUser]     = useState<User | null>(null);
-  const [themas, setThemas] = useState<Thema[]>([]);
 
   useEffect(() => {
     if (localStorage.getItem("loginUser")){
@@ -49,9 +48,7 @@ export default function App() {
   return (
     <Container className={classes.container}>
       <UserContext.Provider value={{user, setUser}}>
-        <ThemaContexts.Provider value={{ themas, setThemas }}>
-          {!user ? <NotLoginRouter /> : <TopScreen />}
-        </ThemaContexts.Provider>
+        {!user ? <WelcomeScreen /> : <LoggedRouter />}
       </UserContext.Provider>
     </Container>
   );

--- a/laravel/resources/ts/app.tsx
+++ b/laravel/resources/ts/app.tsx
@@ -48,7 +48,7 @@ export default function App() {
   return (
     <Container className={classes.container}>
       <UserContext.Provider value={{user, setUser}}>
-        {!user ? <WelcomeScreen /> : <LoggedRouter />}
+        {!user ? <NotLoginRouter /> : <LoggedRouter />}
       </UserContext.Provider>
     </Container>
   );

--- a/laravel/resources/ts/components/InnerWordForm.tsx
+++ b/laravel/resources/ts/components/InnerWordForm.tsx
@@ -1,0 +1,130 @@
+// ---[ import ]----------------------------------------------------------------
+import React, { useEffect, useState, useContext } from 'react';
+import { useParams, useNavigate } from "react-router-dom";
+
+/* contexts */
+import { UserContext } from '../contexts/UserContext';
+
+import axios from 'axios';
+
+/* contexts */
+import { ThemaContexts } from '../contexts/ThemaContext';
+import { InnerWordContexts } from '../contexts/InnerWordContext';
+
+/* types */
+import { InnerWord } from '../type/InnerWord';
+
+/* material-ui */
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, Button,  TextField } from '@material-ui/core';
+
+// ---[ style ]-----------------------------------------------------------------
+const useStyles = makeStyles((theme) =>
+	createStyles({
+		container: {
+			display:         'flex',
+			flexDirection:   'column',
+			padding:         16,
+			borderBottom:    '1px solid black',
+		},
+		container_innner_top: {
+
+		},
+		container_innner_bottom: {
+			marginTop :      8,
+			display:        'flex',
+			flexDirection:  'row-reverse'
+		},
+		input_thema: {
+			width:          '100%',
+		},
+		thema_submit: {
+			borderRadius:   50,
+		},
+  })
+);
+
+// ---[ types ]-----------------------------------------------------------------
+
+
+// ---[ process ]---------------------------------------------------------------
+export const InnerWordForm: React.FC = () => {
+	const classes = useStyles();
+
+	// Set state
+  const {innerWords, setInnerWords} = useContext(InnerWordContexts);
+  const {user, setUser}             = useContext(UserContext);
+	const [innerWord, setInnerWord]   = useState<string>('');
+
+  const themaId = useParams().thema_id;
+
+	const innerWordPost = async() => {
+		// フロントで空をひとまずreturnさせとく
+		if(innerWord === ''){
+			return null;
+		}
+
+		try {
+      await axios
+        .post(`//localhost/api/inner_words/store`, {
+          thema_id:   themaId,
+          inner_word: innerWord
+        })
+        .then((res) => {
+          const resInnerWord = {
+            id:           res.data.inner_word.id,
+            thema_id:     Number(res.data.inner_word.user_id),
+            inner_word:   res.data.inner_word.inner_word,
+            so_word:      res.data.inner_word.so_word,
+            really_word:  res.data.inner_word.really_word,
+            why_word:     res.data.inner_word.why_word,
+            outside_word: res.data.inner_word.outside_word,
+            updated_at:   res.data.inner_word.updated_at,
+            created_at:   res.data.inner_word.created_at,
+          } as InnerWord;
+          setInnerWords([resInnerWord, ...innerWords]);
+
+          // 初期化
+          setInnerWord('');
+        })
+        .catch(error => {
+          console.log(error);
+        });
+      } catch (error) {
+        console.error(error);
+      }
+	}
+
+	// input type onChange logic
+	const inputChangeForm = (input: React.ChangeEvent<any>): void => {
+		const value = input.target.value;
+
+    // setState
+    setInnerWord(value);
+	}
+
+	return (
+		<>
+      <form className={classes.container} method='post'>
+        <TextField
+          className={classes.input_thema}
+          label='内なる言葉を入力してください'
+          variant='outlined'
+          onChange={inputChangeForm}
+          value={innerWord}
+          name='innerWord'
+        />
+        <Box className={classes.container_innner_bottom}>
+        <Button
+          className={classes.thema_submit}
+          variant='contained'
+          color='primary'
+          onClick={innerWordPost}
+        >
+          作成する
+        </Button>
+        </Box>
+      </form>
+		</>
+	);
+}

--- a/laravel/resources/ts/components/InnerWordHeader.tsx
+++ b/laravel/resources/ts/components/InnerWordHeader.tsx
@@ -1,0 +1,68 @@
+// ---[ import ]----------------------------------------------------------------
+import React from 'react';
+import {Link, Routes, Route, useNavigate} from 'react-router-dom';
+
+
+/* material-ui */
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, Typography, Container } from '@material-ui/core';
+
+/* material-ui icon */
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+
+// ---[ styles ]----------------------------------------------------------------
+const useStyles = makeStyles((theme) =>
+	createStyles({
+		container: {
+      display:         'flex',
+      flex:            1,
+      flexDirection:   'row',
+      justifyContent:  'space-between',
+      padding:         16,
+      marginBottom:    16,
+      borderBottom:    '1px solid black',
+		},
+    left_container: {
+      display:         'flex',
+      flex:            1,
+      alignItems:      'center',
+      justifyContent:  'start',
+    },
+    center_container: {
+      display:         'flex',
+      flex:            1,
+      alignItems:      'center',
+      justifyContent:  'center',
+    },
+    right_container: {
+      display:         'flex',
+      flex:            1,
+      alignItems:      'center',
+      justifyContent:  'end',
+    },
+  })
+);
+
+// ---[ styles ]----------------------------------------------------------------
+export const InnerWordHeader = () => {
+  // style
+  const classes = useStyles();
+
+  return (
+    <Container className={classes.container}>
+      <Box className={classes.left_container}>
+        <Link to="/">戻る</Link>
+      </Box>
+      <Box className={classes.center_container}>
+        <Typography
+          variant="h5"
+        >
+          内なる言葉
+        </Typography>
+      </Box>
+      <Box className={classes.right_container}>
+        <MoreHorizIcon />
+      </Box>
+    </Container>
+  );
+}

--- a/laravel/resources/ts/components/InnerWordList.tsx
+++ b/laravel/resources/ts/components/InnerWordList.tsx
@@ -1,0 +1,213 @@
+// ---[ import ]----------------------------------------------------------------
+import React, { useEffect, useState, useContext } from 'react';
+import { useParams, useNavigate } from "react-router-dom";
+
+import axios from 'axios';
+
+/* contexts */
+import { UserContext } from '../contexts/UserContext';
+import { InnerWordContexts } from '../contexts/InnerWordContext';
+
+/* type */
+import { InnerWord } from '../type/InnerWord';
+
+/* material-ui */
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import {
+  Box,
+  Typography,
+  TextField,
+  List,
+  ListItem,
+} from '@material-ui/core';
+/* material-ui icon */
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import CreateIcon from '@mui/icons-material/Create';
+
+// ---[ styles ]----------------------------------------------------------------
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    // container
+    container: {
+      display:                   'flex',
+      flex:                      1,
+      flexDirection:             'column',
+      padding:                   16,
+
+    },
+    // container_parts
+    container_innner_top: {
+      display:                   'flex',
+      flex:                      1,
+      justifyContent:            'space-between',
+      alignItems:                'center',
+      padding:                   16,
+    },
+    container_innner_middle: {
+      padding:                   16,
+    },
+    container_innner_bottom: {
+      display:                   'flex',
+      flexDirection:             'row-reverse',
+      marginTop :                16,
+    },
+    // container_parts_items
+    input_search: {
+      width:                     '200px',
+    },
+    list_item: {
+      display:                   'flex',
+      flex:                      1,
+      alignItems:                'center',
+      marginBottom:              8,
+    },
+    list_item_right: {
+      display:                   'flex',
+      flex:                      1,
+      alignItems:                'center',
+      justifyContent:            'center',
+      height:                    '64px',
+      backgroundColor:           '#fff',
+      border:                    '1px solid black',
+      borderRight:               0,
+      borderTopLeftRadius:       5,
+      borderBottomLeftRadius:    5,
+    },
+    list_item_center: {
+      display:                   'flex',
+      flex:                      10,
+      justifyContent:            'space-between',
+      alignItems:                'center',
+      padding:                   8,
+      height:                    '64px',
+      backgroundColor:           '#fff',
+      border:                    '1px solid black',
+    },
+    list_item_thema_input: {
+        width:                   '100%',
+    },
+    list_item_inner_prev: {
+      display:                   'flex',
+      flex:                      1,
+      backgroundColor:           '#fff',
+      alignItems:                'center',
+      justifyContent:            'center',
+      height:                    '64px',
+      border:                    '1px solid black',
+      borderLeft:                0,
+      borderTopRightRadius:      5,
+      borderBottomRightRadius:   5,
+      "&:hover": {
+        background:              "steelblue",
+        cursor:                  'pointer',
+      },
+    },
+  })
+);
+
+// ---[ process ]---------------------------------------------------------------
+export const InnerWordList: React.FC = () => {
+  // style
+  const classes  = useStyles();
+  const navigate = useNavigate();
+
+  // stateを宣言
+  const {user, setUser}             = useContext(UserContext);
+  const {innerWords, setInnerWords} = useContext(InnerWordContexts);
+
+  const themaId = useParams().thema_id;
+
+  // 画面マウント時
+  useEffect(() => {
+    fetchInnerWords()
+  }, [])
+
+  // 内なる言葉を取得
+  const fetchInnerWords = async () => {
+    try {
+      const innerWordList = await axios.get(
+        `//localhost/api/inner_words?thema_id=${themaId}`
+      )
+      setInnerWords(innerWordList.data.inner_word);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 内なる言葉の変更処理
+	const onChangeInnerWord = (
+    input: React.ChangeEvent<any>,
+    index: any
+  ): void => {
+    setInnerWords(
+      innerWords.map((obj, objIndex) => (
+        index === objIndex
+          ? {...obj, inner_word: input.target.value}
+          : obj
+      ))
+    )
+    // feature update api logic
+	}
+
+  // 内なる言葉の詳細へ
+  const prevInnerWordDetail = (
+    input: React.ChangeEvent<any>,
+    innerWord: number
+  ) => {
+    navigate(`/inner_word/${innerWord}`);
+  }
+
+
+  // returns element
+  return (
+    <Box className={classes.container}>
+        <Box className={classes.container_innner_top}>
+          <Typography>内なる言葉</Typography>
+          <TextField
+            id='filled-search'
+            className={classes.input_search}
+            label='検索する'
+            variant='filled'
+            InputProps={{ disableUnderline: true }}
+          />
+        </Box>
+        <Box className={classes.container_innner_middle}>
+            feature: A component of sorts will go in here.
+        </Box>
+        <Box>
+          <List>
+            {
+              innerWords.map((innerWord, index) => (
+                <ListItem
+                  key={index.toString()}
+                  className={classes.list_item}
+                >
+                  <Box className={classes.list_item_right} >
+                    <StarBorderIcon/>
+                  </Box>
+                  <Box className={classes.list_item_center}>
+                    <TextField
+                      className={classes.list_item_thema_input}
+                      id='outlined'
+                      InputProps={{ disableUnderline: true }}
+                      value={innerWord.inner_word}
+                      onChange={(e) => (onChangeInnerWord(e, index))}
+                    />
+                    <MoreHorizIcon />
+                  </Box>
+                  <Box
+                    className={classes.list_item_inner_prev}
+                    onClick={(e) => (prevInnerWordDetail(e, innerWord.id))}
+                  >
+                    <CreateIcon />
+                  </Box>
+                </ListItem>
+              ))
+            }
+          </List>
+        </Box>
+    </Box>
+  );
+}

--- a/laravel/resources/ts/components/ThemaList.tsx
+++ b/laravel/resources/ts/components/ThemaList.tsx
@@ -1,21 +1,15 @@
 // ---[ import ]----------------------------------------------------------------
 import React, { useEffect, useState, useContext } from 'react';
-import ReactDOM from 'react-dom';
+import { useNavigate } from "react-router-dom";
 
 import axios from 'axios';
 
 /* contexts */
 import { UserContext } from '../contexts/UserContext';
-
-/* contexts */
 import { ThemaContexts } from '../contexts/ThemaContext';
 
 /* type */
 import { User } from '../type/User';
-
-/* ApiList */
-
-/* types */
 import { Thema } from '../type/Thema';
 
 /* material-ui */
@@ -105,6 +99,10 @@ const useStyles = makeStyles((theme) =>
       borderLeft:                0,
       borderTopRightRadius:      5,
       borderBottomRightRadius:   5,
+      "&:hover": {
+        background:              "steelblue",
+        cursor:                  'pointer',
+      },
     },
   })
 );
@@ -112,7 +110,8 @@ const useStyles = makeStyles((theme) =>
 // ---[ process ]---------------------------------------------------------------
 export const ThemaList: React.FC = () => {
   // style
-  const classes = useStyles();
+  const classes  = useStyles();
+  const navigate = useNavigate();
 
   // state
   const {user, setUser}     = useContext(UserContext);
@@ -136,7 +135,10 @@ export const ThemaList: React.FC = () => {
   };
 
   // update Thema
-	const onChangeThema = (input: React.ChangeEvent<any>, index: any): void => {
+	const onChangeThema = (
+    input: React.ChangeEvent<any>,
+    index: any
+  ): void => {
     setThemas(
       themas.map((obj, objIndex) => (
         index === objIndex
@@ -146,6 +148,13 @@ export const ThemaList: React.FC = () => {
     )
     // feature update api logic
 	}
+
+  const prevInnerWord = (
+    input: React.ChangeEvent<any>,
+    thema_id: number
+  ) => {
+    navigate(`/inner_word/${thema_id}`);
+  }
 
   return (
     <>
@@ -164,33 +173,36 @@ export const ThemaList: React.FC = () => {
               feature: A component of sorts will go in here.
           </Box>
           <Box>
-              <List>
-                {
-                  themas.map((thema, index) => (
-                    <ListItem
-                      key={index.toString()}
-                      className={classes.list_item}
+            <List>
+              {
+                themas.map((thema, index) => (
+                  <ListItem
+                    key={index.toString()}
+                    className={classes.list_item}
+                  >
+                    <Box className={classes.list_item_right} >
+                      <StarBorderIcon/>
+                    </Box>
+                    <Box className={classes.list_item_center}>
+                      <TextField
+                        className={classes.list_item_thema_input}
+                        id='outlined'
+                        InputProps={{ disableUnderline: true }}
+                        value={thema.thema}
+                        onChange={(e) => (onChangeThema(e, index))}
+                        />
+                      <MoreHorizIcon />
+                    </Box>
+                    <Box
+                      className={classes.list_item_inner_prev}
+                      onClick={(e) => (prevInnerWord(e, thema.id))}
                     >
-                      <Box className={classes.list_item_right} >
-                        <StarBorderIcon/>
-                      </Box>
-                      <Box className={classes.list_item_center}>
-                        <TextField
-                          className={classes.list_item_thema_input}
-                          id='outlined'
-                          InputProps={{ disableUnderline: true }}
-                          value={thema.thema}
-                          onChange={(e) => (onChangeThema(e, index))}
-                         />
-                        <MoreHorizIcon />
-                      </Box>
-                      <Box className={classes.list_item_inner_prev} >
-                        <NavigateNextIcon />
-                      </Box>
-                    </ListItem>
-                  ))
-                }
-              </List>
+                      <NavigateNextIcon />
+                    </Box>
+                  </ListItem>
+                ))
+              }
+            </List>
           </Box>
       </Box>
     </>

--- a/laravel/resources/ts/contexts/InnerWordContext.ts
+++ b/laravel/resources/ts/contexts/InnerWordContext.ts
@@ -1,0 +1,16 @@
+// ---[ import ]----------------------------------------------------------------
+import { createContext } from "react";
+/* type */
+import { InnerWord } from '../type/InnerWord';
+
+// ---[ type ]------------------------------------------------------------------
+type InnerWordContextValue ={
+  innerWords:     InnerWord[];
+  setInnerWords:  (innerWords: InnerWord[]) => void;
+}
+
+// ---[ process ]---------------------------------------------------------------
+export const InnerWordContexts = createContext<InnerWordContextValue>({
+  innerWords:     [],
+  setInnerWords:  () => {}
+})

--- a/laravel/resources/ts/routes/LoggedRouter.tsx
+++ b/laravel/resources/ts/routes/LoggedRouter.tsx
@@ -1,0 +1,27 @@
+// ---[ import ]----------------------------------------------------------------
+import React from 'react';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
+/* screens */
+import { TopScreen } from '../screens/TopScreen';
+import { InnerWordScreen } from '../screens/InnerWordScreen';
+import { RegisterScreen } from '../screens/RegisterScreen';
+import { LoginScreen } from '../screens/LoginScreen';
+import { PageNotFound } from '../screens/PageNotFound';
+
+// ---[ styles ]----------------------------------------------------------------
+export const LoggedRouter = () => {
+  return (
+    <>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<TopScreen />} />
+          <Route path="/inner_word/:thema_id" element={<InnerWordScreen />} />
+          <Route path="/login" element={<LoginScreen />} />
+          <Route path="/register" element={<RegisterScreen />} />
+          <Route path="*" element={<PageNotFound />} />
+        </Routes>
+      </BrowserRouter>
+    </>
+  );
+}

--- a/laravel/resources/ts/routes/NotLoginRouter.tsx
+++ b/laravel/resources/ts/routes/NotLoginRouter.tsx
@@ -1,6 +1,6 @@
 // ---[ import ]----------------------------------------------------------------
-import React, { useEffect, useState } from 'react';
-import { BrowserRouter, Routes, Route, NavLink } from "react-router-dom";
+import React from 'react';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { WelcomeScreen } from '../screens/WelcomeScreen';
 import { RegisterScreen } from '../screens/RegisterScreen';

--- a/laravel/resources/ts/screens/InnerWordScreen.tsx
+++ b/laravel/resources/ts/screens/InnerWordScreen.tsx
@@ -1,0 +1,44 @@
+// ---[ import ]----------------------------------------------------------------
+import React, { useState } from 'react';
+
+/* contexts */
+import { InnerWordContexts } from '../contexts/InnerWordContext';
+
+/* components */
+import { InnerWordForm } from '../components/InnerWordForm';
+import { InnerWordList } from '../components/InnerWordList';
+import { InnerWordHeader } from '../components/InnerWordHeader';
+
+/* type */
+import { InnerWord } from '../type/InnerWord';
+
+/* material-ui */
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { Container } from '@material-ui/core';
+
+// ---[ styles ]----------------------------------------------------------------
+const useStyles = makeStyles((theme) =>
+	createStyles({
+		container: {
+      width: "80%"
+		},
+  })
+);
+
+// ---[ styles ]----------------------------------------------------------------
+export const InnerWordScreen = () => {
+  // style
+  const classes  = useStyles();
+
+  const [innerWords, setInnerWords] = useState<InnerWord[]>([]);
+
+  return (
+    <Container className={classes.container}>
+      <InnerWordContexts.Provider value={{ innerWords, setInnerWords }}>
+        <InnerWordHeader />
+        <InnerWordForm />
+        <InnerWordList />
+      </InnerWordContexts.Provider>
+    </Container>
+  );
+}

--- a/laravel/resources/ts/screens/LoginScreen.tsx
+++ b/laravel/resources/ts/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 // ---[ import ]----------------------------------------------------------------
 import React, { useEffect, useState, useContext } from 'react';
+import { useNavigate } from "react-router-dom";
 
 
 import axios from 'axios';
@@ -87,7 +88,8 @@ type LoginPram = {
 
 // ---[ process ]---------------------------------------------------------------
 export const LoginScreen = () => {
-  const classes = useStyles();
+  const classes  = useStyles();
+  const navigate = useNavigate();
 
   // state
   const {user, setUser}                 = useContext(UserContext);
@@ -120,6 +122,7 @@ export const LoginScreen = () => {
             setErrorMessage(['ログインに失敗しました'])
           });
         })
+      navigate('/');
     } catch (error) {
       console.error(error);
     }

--- a/laravel/resources/ts/screens/LoginScreen.tsx
+++ b/laravel/resources/ts/screens/LoginScreen.tsx
@@ -81,7 +81,7 @@ const useStyles = makeStyles((theme) =>
 
 // ---[ types ]-----------------------------------------------------------------
 type LoginPram = {
-	email:     string;
+	email:    string;
 	password: string;
 }
 
@@ -90,9 +90,9 @@ export const LoginScreen = () => {
   const classes = useStyles();
 
   // state
-  const {user, setUser}                   = useContext(UserContext);
-  const [formData, setFormData]           = useState<LoginPram>({email: '', password: ''});
-  const [errorMessage, setErrorMessage]   = useState<string[]>([]);
+  const {user, setUser}                 = useContext(UserContext);
+  const [formData, setFormData]         = useState<LoginPram>({email: '', password: ''});
+  const [errorMessage, setErrorMessage] = useState<string[]>([]);
 
   const login = async() => {
     try {

--- a/laravel/resources/ts/screens/TopScreen.tsx
+++ b/laravel/resources/ts/screens/TopScreen.tsx
@@ -2,9 +2,15 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
+/* contexts */
+import { ThemaContexts } from '../contexts/ThemaContext';
+
 /* components */
-import { CreateThemaForm } from '../components/form/Thema';
+import { CreateThemaForm } from '../components/form/thema';
 import { ThemaList } from '../components/ThemaList';
+
+/* type */
+import { Thema } from '../type/Thema';
 
 /* material-ui */
 import { createStyles, makeStyles } from '@material-ui/core/styles';
@@ -24,10 +30,14 @@ export const TopScreen = () => {
   // style
   const classes = useStyles();
 
+  const [themas, setThemas] = useState<Thema[]>([]);
+
   return (
     <Container className={classes.container}>
-      <CreateThemaForm />
-      <ThemaList />
+      <ThemaContexts.Provider value={{ themas, setThemas }}>
+        <CreateThemaForm />
+        <ThemaList />
+      </ThemaContexts.Provider>
     </Container>
   );
 }

--- a/laravel/resources/ts/type/InnerWord.ts
+++ b/laravel/resources/ts/type/InnerWord.ts
@@ -1,7 +1,7 @@
 export type InnerWord = {
 	id:           number
 	thema_id:     number
-	Inner_word:   string
+	inner_word:   string
   so_word:      string
   really_word:  string
   why_word:     string

--- a/laravel/resources/ts/type/InnerWord.ts
+++ b/laravel/resources/ts/type/InnerWord.ts
@@ -1,0 +1,11 @@
+export type InnerWord = {
+	id:           number
+	thema_id:     number
+	Inner_word:   string
+  so_word:      string
+  really_word:  string
+  why_word:     string
+	outside_word: string
+	updated_at:   Date
+	created_at:   Date
+}

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -27,4 +27,12 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
   // relation theme
   Route::get('thema', 'App\Http\Controllers\ThemaController@index');
   Route::post('thema/store', 'App\Http\Controllers\ThemaController@store');
+
+  // relation theme
+  Route::get('inner_words', 'App\Http\Controllers\InnerWordController@index');
+  Route::post('inner_words/store', 'App\Http\Controllers\InnerWordController@store');
+});
+
+Route::group(['middleware' => 'api'], function(){
+
 });


### PR DESCRIPTION
#  innerWordの新規作成ロジックを作成

##  summary
- 画面遷移ロジックを追加
- innerWord画面のUI作成
- innerWord画面のフロント処理作成
- innerWord画面のバックエンド作成
- 
##  contents
- inner_wordテーブルの構成を修正。（null許可の処理）
- react-routerの導入
- 画面遷移をrouterで実装
- Themacontextの範囲をtopのみに修正(propでいいのでは)

##  note
- 自動ログイン時に画面がちらつく
画面をUsercontextを持っているかで切り替えているため、stateがセットされるまでの間、ログインしていない時の画面がチラついてしまう。自動ログインロジック修正時に改修の必要あり？